### PR TITLE
Correct legend of MGMWM plots

### DIFF
--- a/R/GMWM.R
+++ b/R/GMWM.R
@@ -836,6 +836,9 @@ plot.gmwm = function(x, decomp = TRUE,
   
   
   # SOME CHECKS SHOULD BE ADDED
+  
+  if(is.null(col_wv)) {col_wv="#003C7D"}
+  if(is.null(col_ci)) {col_ci="#003C7D"}
 
   par(mar=c(5.1, 5.1, 1, 12))
   plot(x$wv, legend_position = NA, ylab = ylab, 
@@ -949,6 +952,9 @@ plot.mgmwm = function(x, decomp = TRUE,
   
   # SOME CHECKS SHOULD BE ADDED
 
+  if(is.null(col_wv)) {col_wv="#003C7D"}
+  if(is.null(col_ci)) {col_ci="#003C7D"}  
+  
   par(mar=c(5.1, 5.1, 1, 12))
   plot(x$wv, legend_position = NA, xlab = xlab, ylab = ylab, 
        col_wv = col_wv, ci_wv = FALSE)


### PR DESCRIPTION
This pull request fixes #225. Formerly, there was a mismatch between legend entries and actual plots.
The legend matches nicely now (only tested with `mgmwm`, though).
![image](https://github.com/SMAC-Group/gmwm/assets/7974580/ce763294-0a91-4584-951d-3e5043296181)
![image](https://github.com/SMAC-Group/gmwm/assets/7974580/0617ccb4-2452-4b8a-bad7-b425db532a41)

